### PR TITLE
Add itemTextFontFamily property

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ import { WheelPicker, DatePicker, TimePicker } from 'react-native-wheel-picker-a
 | curtainColor | transparent | `string` | Wheel Picker curtain color  |
 | itemTextColor | grey | `string` | Wheel Picker's items color  |
 | itemTextSize | 20 | `number` |  Wheel Picker's items text size  |
+| itemTextFontFamily | null | `string` | Wheel Picker's items text font name  |
 | selectedItemPosition | null | `number` | Select current item position |
 | backgroundColor | transparent | `string` | Wheel Picker background color  |
 

--- a/Tests/WheelPicker.test.js
+++ b/Tests/WheelPicker.test.js
@@ -16,7 +16,7 @@ test('component structure', (t) => {
 
 test('props', (t) => {
   const data = [1, 2, 3];
-  const wrapperPress = shallow(<WheelPicker selectedItemTextColor={'yellow'} itemSpace={39} renderIndicator indicatorColor={'grey'} curtainColor={'green'} itemTextColor={'white'} itemTextSize={23} selectedItemPosition={1} isCyclic={false} isCurved isAtmospheric visibleItemCount={4} backgroundColor={'black'} data={data} />);
+  const wrapperPress = shallow(<WheelPicker selectedItemTextColor={'yellow'} itemSpace={39} renderIndicator indicatorColor={'grey'} curtainColor={'green'} itemTextColor={'white'} itemTextFontFamily={'Tahoma'} itemTextSize={23} selectedItemPosition={1} isCyclic={false} isCurved isAtmospheric visibleItemCount={4} backgroundColor={'black'} data={data} />);
 
   t.is(wrapperPress.prop('data').length, 3);
   t.is(wrapperPress.prop('isCurved'), true);
@@ -27,6 +27,7 @@ test('props', (t) => {
   t.is(wrapperPress.prop('selectedItemPosition'), 1);
   t.is(wrapperPress.prop('itemTextSize'), 23);
   t.is(wrapperPress.prop('itemTextColor'), 'white');
+  t.is(wrapperPress.prop('itemTextFontFamily'), 'Tahoma');
   t.is(wrapperPress.prop('curtainColor'), 'green');
   t.is(wrapperPress.prop('renderIndicator'), true);
   t.is(wrapperPress.prop('indicatorColor'), 'grey');

--- a/WheelPicker.js
+++ b/WheelPicker.js
@@ -34,6 +34,7 @@ class WheelPicker extends React.Component {
          curtainColor={this.props.curtainColor}
          itemTextColor={this.props.itemTextColor}
          itemTextSize={this.props.itemTextSize}
+         itemTextFontFamily={this.props.itemTextFontFamily}
          selectedItemPosition={this.props.selectedItemPosition}
          backgroundColor={this.props.backgroundColor}
          />
@@ -56,6 +57,7 @@ WheelPicker.propTypes = {
       curtainColor: PropTypes.string,
       itemTextColor: PropTypes.string,
       itemTextSize: PropTypes.number,
+      itemTextFontFamily: PropTypes.string,
       selectedItemPosition: PropTypes.number,
       backgroundColor: PropTypes.string,
 };

--- a/android/src/main/java/com/wheelpicker/WheelPickerManager.java
+++ b/android/src/main/java/com/wheelpicker/WheelPickerManager.java
@@ -19,7 +19,6 @@ import java.util.List;
 public class WheelPickerManager extends SimpleViewManager<WheelPicker>  implements WheelPicker.OnItemSelectedListener{
 
     public static final String REACT_CLASS = "WheelPicker";
-    private ThemedReactContext ctx;
 
     @Override
     public String getName() {
@@ -28,7 +27,6 @@ public class WheelPickerManager extends SimpleViewManager<WheelPicker>  implemen
 
     @Override
     protected WheelPicker createViewInstance(ThemedReactContext context) {
-        ctx = context;
         WheelPicker wheelPicker = new WheelPicker(context);
         wheelPicker.setOnItemSelectedListener(this);
         return wheelPicker;
@@ -171,8 +169,7 @@ public class WheelPickerManager extends SimpleViewManager<WheelPicker>  implemen
             }
         }
         event.putInt("position", position);
-        ReactContext reactContext = (ReactContext) ctx;
-        reactContext.getJSModule(RCTEventEmitter.class).receiveEvent(
+        ((ReactContext) wheelPicker.getContext()).getJSModule(RCTEventEmitter.class).receiveEvent(
             picker.getId(),
             "topChange",
             event);

--- a/android/src/main/java/com/wheelpicker/WheelPickerManager.java
+++ b/android/src/main/java/com/wheelpicker/WheelPickerManager.java
@@ -12,7 +12,9 @@ import com.facebook.react.uimanager.annotations.ReactProp;
 import com.facebook.react.uimanager.SimpleViewManager;
 import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.events.RCTEventEmitter;
+import com.facebook.react.views.text.ReactFontManager;
 import android.graphics.Color;
+import android.graphics.Typeface;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -141,6 +143,14 @@ public class WheelPickerManager extends SimpleViewManager<WheelPicker>  implemen
         }
     }
 
+    @ReactProp(name = "itemTextFontFamily")
+    public void setSelectedItemPosition(WheelPicker wheelPicker, String itemTextFontFamily) {
+      if (wheelPicker!=null){
+        Typeface typeface = ReactFontManager.getInstance().getTypeface(itemTextFontFamily, Typeface.NORMAL, wheelPicker.getContext().getAssets());
+        wheelPicker.setTypeface(typeface);
+      }
+    }
+
     @ReactProp(name = "selectedItemPosition")
     public void setSelectedItemPosition(WheelPicker wheelPicker, int selectedItemPosition) {
         if (wheelPicker!=null){
@@ -169,7 +179,7 @@ public class WheelPickerManager extends SimpleViewManager<WheelPicker>  implemen
             }
         }
         event.putInt("position", position);
-        ((ReactContext) wheelPicker.getContext()).getJSModule(RCTEventEmitter.class).receiveEvent(
+        ((ReactContext) picker.getContext()).getJSModule(RCTEventEmitter.class).receiveEvent(
             picker.getId(),
             "topChange",
             event);


### PR DESCRIPTION
This property gives the ability to change picker-item fonts
I also removed `context` field in `WheelPickerManager` because it was unnecessary and could be fetched using `(ReactContext) wheelPicker.getContext()` when required.