### PR TITLE
Implemented format24-prop for TimePicker

### DIFF
--- a/DatePicker.js
+++ b/DatePicker.js
@@ -51,7 +51,7 @@ class DatePicker extends React.Component {
           isCyclic
           isCurved
           visibleItemCount={8}
-          data={this.props.hours ? this.props.hours : getHoursArray()}
+          data={this.props.hours ? this.props.hours : getHoursArray(this.props.format24)}
           selectedItemTextColor={'black'}
           onItemSelected={data => this.onHourSelected(data)}
           selectedItemPosition={this.initHourInex}
@@ -215,9 +215,12 @@ function formatDatePicker(date) {
   return strDate;
 }
 
-function getHoursArray() {
+function getHoursArray(is24Hour = false) {
+  const maxHour = is24Hour ? 24 : 13
+  const minHour = is24Hour ? 0 : 1
   const arr = [];
-  for (let i = 1; i < 13; i++) {
+
+  for (let i = minHour; i < maxHour; i++) {
     arr.push(i);
   }
   return arr;

--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ Callback with event in the form `event = { data: 1, position: 0 }`
 | initDate | current date | `ISOString` | Initial selected time  |
 | hours | [1, 2, 3, .. 12] | `array` | hours array |
 | minutes | ['00', '05' ,'10', .. '55'] | `array` | minutes array |
+| format24 | false | `bool` | if true hours format is 24 hours|
 
 
 ## Date Picker

--- a/TimePicker.js
+++ b/TimePicker.js
@@ -27,9 +27,11 @@ class TimePicker extends React.Component {
     super(props);
     this.selectedDate = this.props.initDate ? new Date(this.props.initDate) : new Date();
     const time12format = hourTo12Format(this.selectedDate.getHours());
-    this.hours = this.props.hours ? this.props.hours : getHoursArray();
+    const time24format = this.selectedDate.getHours();
+
+    this.hours = this.props.hours ? this.props.hours : getHoursArray(this.props.format24);
     this.minutes = this.props.minutes ? this.props.minutes : getFiveMinutesArray();
-    this.initHourInex = time12format[0] - 1;
+    this.initHourInex = this.props.format24 ? time24format : time12format[0] - 1;
     const minutesCount = this.props.minutes ? this.props.minutes.length : 12
     const minutesInHour = 60
     this.initMinuteInex = Math.round(this.selectedDate.getMinutes() / (minutesInHour / minutesCount));
@@ -61,7 +63,7 @@ class TimePicker extends React.Component {
           onItemSelected={data => this.onMinuteSelected(data)}
           selectedItemPosition={this.initMinuteInex}
         />
-        <WheelPicker
+        {!this.props.format24 && <WheelPicker
           style={styles.wheelPicker}
           isAtmospheric
           isCurved
@@ -70,16 +72,20 @@ class TimePicker extends React.Component {
           selectedItemTextColor={'black'}
           onItemSelected={data => this.onAmSelected(data)}
           selectedItemPosition={this.initAmInex}
-        />
+        />}
       </View>
     );
   }
 
   onHourSelected(event) {
-    const time12format = hourTo12Format(this.selectedDate.getHours());
-    const newTime12Format = `${event.data} ${time12format[1]}`;
-    const selectedHour24format = hourTo24Format(newTime12Format);
-    this.selectedDate.setHours(selectedHour24format);
+    if (this.props.format24) {
+      this.selectedDate.setHours(event.data);
+    } else {
+      const time12format = hourTo12Format(this.selectedDate.getHours());
+      const newTime12Format = `${event.data} ${time12format[1]}`;
+      const selectedHour24format = hourTo24Format(newTime12Format);
+      this.selectedDate.setHours(selectedHour24format);
+    }
     this.onTimeSelected();
   }
 
@@ -109,6 +115,7 @@ TimePicker.propTypes = {
   onTimeSelected: PropTypes.func,
   hours: PropTypes.array,
   minutes: PropTypes.array,
+  format24: PropTypes.bool,
 };
 
 // it takes in format '12 AM' and return 24 format
@@ -137,9 +144,12 @@ const dateTo12Hour = (dateString) => {
   return [(hour.toString()), (amPm)];
 };
 
-function getHoursArray() {
+function getHoursArray(is24Hour = false) {
+  const maxHour = is24Hour ? 24 : 13
+  const minHour = is24Hour ? 0 : 1
   const arr = [];
-  for (let i = 1; i < 13; i++) {
+
+  for (let i = minHour; i < maxHour; i++) {
     arr.push(i);
   }
   return arr;


### PR DESCRIPTION
24 hour format was implemented for `DatePicker`, but not for `TimePicker`. 
![timepicker](https://user-images.githubusercontent.com/2505178/31821026-e63feeda-b5a3-11e7-9837-b657c7c0e5f9.png)

I also added 24 hour array to `DatePicker` when `format24` is set to true:
![datepicker](https://user-images.githubusercontent.com/2505178/31821031-eb38128c-b5a3-11e7-907d-906a8edb3094.png)