### PR TITLE
Added wheelpicker dependency with github as source

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,18 @@ Also you can use multiple pickers, such as DatePicker or TimePicker
 ## Installation Android
 1. `npm install react-native-wheel-picker-android --save`
 2. `react-native link react-native-wheel-picker-android`
+3. In `android/build.gradle` add the jitpack repository to your project.
+
+```diff
+allprojects {
+    repositories {
+        ...
++       maven {
++          url "https://jitpack.io"
++       }
+    }
+}
+```
 
 # Usage
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -18,5 +18,5 @@ android {
 dependencies {
     compile 'com.android.support:appcompat-v7:23.0.0'
     compile 'com.facebook.react:react-native:0.19.+'
-    compile 'cn.aigestudio.wheelpicker:WheelPicker:1.1.2'
+    compile 'com.github.AigeStudio:WheelPicker:master-SNAPSHOT'
 }


### PR DESCRIPTION
Currently WheelPicker v1.1.2 is used as a dependency for this module, but in the master branch there have been some bugfixes, e.g. will this PR resolve #29. 

By using jitpack.io we can use current master instead of waiting for the version number to be updated. A downside of using jitpack is that it will not be included with `react-native link`, and therefore a manual step is required.

I understand that using the master branch may seem unsafe, so this is up to discussion.