### PR TITLE
Add the ability to customize DatePicker & TimePicker text colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,8 @@ Callback with event in the form `event = { data: 1, position: 0 }`
 | initDate | current date | `ISOString` | Initial selected time  |
 | hours | [1, 2, 3, .. 12] | `array` | hours array |
 | minutes | ['00', '05' ,'10', .. '55'] | `array` | minutes array |
+| itemTextColor | grey | `string` | Time Picker's items color  |
+| selectedItemTextColor | black | `string` | Time Picker's selected Item Text Color  |
 
 
 ## Date Picker
@@ -200,6 +202,8 @@ Callback with event in the form `event = { data: 1, position: 0 }`
 | format24 | false | `bool` | if true hours format is 24 hours|
 | startDate | current date | `ISOString` | The Earlest date |
 | daysCount | 365 | `number` | How many days included in Date Picker |
+| itemTextColor | grey | `string` | Date Picker's items color  |
+| selectedItemTextColor | black | `string` | Date Picker's selected Item Text Color  |
 
 ## Questions or suggestions?
 

--- a/src/DatePicker.js
+++ b/src/DatePicker.js
@@ -33,6 +33,8 @@ type Props = {
   startDate: string,
   daysCount: number,
   days: Array<number>,
+  itemTextColor?: string,
+  selectedItemTextColor?: string,
 }
 
 type State = {
@@ -83,7 +85,16 @@ export default class DatePicker extends React.Component<Props, State> {
   }
 
   render() {
-    const { startDate, days, daysCount, hours, minutes, format24 } = this.props
+    const {
+      startDate,
+      days,
+      daysCount,
+      hours,
+      minutes,
+      format24,
+      itemTextColor = 'grey',
+      selectedItemTextColor = 'black',
+    } = this.props
     const { initHourInex, initDayInex, initMinuteInex } = this.state
     return (
       <View style={styles.container}>
@@ -93,7 +104,8 @@ export default class DatePicker extends React.Component<Props, State> {
           isCurved
           visibleItemCount={8}
           data={days || pickerDateArray(startDate, daysCount)}
-          selectedItemTextColor={'black'}
+          itemTextColor={itemTextColor}
+          selectedItemTextColor={selectedItemTextColor}
           onItemSelected={this.onDaySelected}
           selectedItemPosition={initDayInex}
         />
@@ -104,7 +116,8 @@ export default class DatePicker extends React.Component<Props, State> {
           isCurved
           visibleItemCount={8}
           data={hours || getHoursArray(format24)}
-          selectedItemTextColor={'black'}
+          itemTextColor={itemTextColor}
+          selectedItemTextColor={selectedItemTextColor}
           onItemSelected={this.onHourSelected}
           selectedItemPosition={initHourInex}
         />
@@ -115,7 +128,8 @@ export default class DatePicker extends React.Component<Props, State> {
           isCurved
           visibleItemCount={8}
           data={minutes || getFiveMinutesArray()}
-          selectedItemTextColor={'black'}
+          itemTextColor={itemTextColor}
+          selectedItemTextColor={selectedItemTextColor}
           onItemSelected={this.onMinuteSelected}
           selectedItemPosition={initMinuteInex}
         />
@@ -125,6 +139,10 @@ export default class DatePicker extends React.Component<Props, State> {
   }
 
   renderAm() {
+    const {
+      itemTextColor = 'grey',
+      selectedItemTextColor = 'black',
+    } = this.props
     const { initAmInex } = this.state
     return (
       <WheelPicker
@@ -133,7 +151,8 @@ export default class DatePicker extends React.Component<Props, State> {
         isCurved
         visibleItemCount={8}
         data={getAmArray()}
-        selectedItemTextColor={'black'}
+        itemTextColor={itemTextColor}
+        selectedItemTextColor={selectedItemTextColor}
         onItemSelected={this.onAmSelected}
         selectedItemPosition={initAmInex}
       />

--- a/src/TimePicker.js
+++ b/src/TimePicker.js
@@ -28,6 +28,8 @@ type Props = {
   hours: Array<number>,
   minutes: Array<string>,
   format24: boolean,
+  itemTextColor?: string,
+  selectedItemTextColor?: string,
 }
 
 type State = {
@@ -65,6 +67,10 @@ export default class TimePicker extends React.Component<Props, State> {
   }
 
   render() {
+    const {
+      itemTextColor = 'grey',
+      selectedItemTextColor = 'black',
+    } = this.props
     const { hours, initHourInex, minutes, initMinuteInex } = this.state
     return (
       <View style={styles.container}>
@@ -75,7 +81,8 @@ export default class TimePicker extends React.Component<Props, State> {
           isCurved
           visibleItemCount={6}
           data={hours}
-          selectedItemTextColor={'black'}
+          itemTextColor={itemTextColor}
+          selectedItemTextColor={selectedItemTextColor}
           onItemSelected={this.onHourSelected}
           selectedItemPosition={initHourInex}
         />
@@ -86,7 +93,8 @@ export default class TimePicker extends React.Component<Props, State> {
           isCurved
           visibleItemCount={6}
           data={minutes}
-          selectedItemTextColor={'black'}
+          itemTextColor={itemTextColor}
+          selectedItemTextColor={selectedItemTextColor}
           onItemSelected={this.onMinuteSelected}
           selectedItemPosition={initMinuteInex}
         />
@@ -96,6 +104,7 @@ export default class TimePicker extends React.Component<Props, State> {
   }
 
   renderAm() {
+    const { itemTextColor, selectedItemTextColor } = this.props
     const { initAmInex } = this.state
     return (
       <WheelPicker
@@ -104,7 +113,8 @@ export default class TimePicker extends React.Component<Props, State> {
         isCurved
         visibleItemCount={8}
         data={getAmArray()}
-        selectedItemTextColor={'black'}
+        itemTextColor={itemTextColor}
+        selectedItemTextColor={selectedItemTextColor}
         onItemSelected={this.onAmSelected}
         selectedItemPosition={initAmInex}
       />
@@ -158,3 +168,4 @@ const styles = StyleSheet.create({
     flex: 1,
   },
 })
+


### PR DESCRIPTION
Currently the WheelPicker supports this, but the DatePicker & TimePicker do not. This should not be a breaking change. I'm happy to make another PR adding the ability to customize the font size & font family.