### PR TITLE
Remove second argument of requireNativeComponent

### DIFF
--- a/src/WheelPicker.js
+++ b/src/WheelPicker.js
@@ -6,7 +6,7 @@
 import React from 'react'
 import { requireNativeComponent } from 'react-native'
 
-const WheelPickerView = requireNativeComponent('WheelPicker', WheelPicker)
+const WheelPickerView = requireNativeComponent('WheelPicker', null)
 
 type Props = {
   onItemSelected: any => void,


### PR DESCRIPTION
This fixes the flow error
```
Cannot use variable WheelPicker [1] because the declaration either comes later or was skipped
```
Since this library is using flow instead of `propTypes`, the second argument does not need to be passed in.