### PR TITLE
Extend RNPicker props

### DIFF
--- a/src/WheelPicker.ios.tsx
+++ b/src/WheelPicker.ios.tsx
@@ -1,8 +1,8 @@
 import React, { useState } from "react";
 import { View } from "react-native";
-import { Picker } from "@react-native-community/picker";
+import { Picker, PickerProps } from "@react-native-community/picker";
 
-interface Props {
+interface Props extends PickerProps {
   data: Array<string>;
   selectedItem?: number;
   onItemSelected?: Function;


### PR DESCRIPTION
So we can use `itemStyle` and other options without syntax errors.

```jsx
<WheelPicker
    selectedItem={this.state.selectedItem}
    data={wheelPickerData}
    onItemSelected={this.onItemSelected}
    // Add itemStyle as per @react-native-community/picker docs
    // @reference https://github.com/react-native-picker/picker#props-1
    itemStyle={{ color: "white" }}
    {...moreIosProps}
  />
```

It would also remove both of these users "syntax errors" since it does actually work if you pass those props.
https://github.com/Cero-Studio/ReactNativeWheelPicker/issues/160
https://github.com/Cero-Studio/ReactNativeWheelPicker/issues/159

