### PR TITLE
itemTextFontFamily and selectedItemTextFontFamily props set optional

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -4,10 +4,10 @@ import { DatePickerIOSProps, StyleProp, ViewStyle } from 'react-native';
 interface IStyle {
 	selectedItemTextColor?: string;
 	selectedItemTextSize?: number;
-	selectedItemTextFontFamily: string;
+	selectedItemTextFontFamily?: string;
 	itemTextColor?: string;
 	itemTextSize?: number;
-	itemTextFontFamily: string;
+	itemTextFontFamily?: string;
 	indicatorColor?: string;
 	hideIndicator?: boolean;
 	indicatorWidth?: number;


### PR DESCRIPTION
As reported in issue #183, `itemTextFontFamily` and `selectedItemTextFontFamily` props should be optional.

Their usage in README is not reported as mandatory and the example usages don't use them.